### PR TITLE
Pull request per your request - fix for issues #147, 148

### DIFF
--- a/chromeipass/background/event.js
+++ b/chromeipass/background/event.js
@@ -5,7 +5,8 @@ event.onMessage = function(request, sender, callback) {
 	if (request.action in event.messageHandlers) {
 		//console.log("onMessage(" + request.action + ") for #" + sender.tab.id);
 
-		if(sender.tab.id < 1) {
+		if(!sender.hasOwnProperty('tab') || sender.tab.id < 1) {
+			sender.tab = {};
 			sender.tab.id = page.currentTabId;
 		}
 


### PR DESCRIPTION
Newer versions of Chrome don't send the tab property of sender.
Explicitly creating tab property fixes issue.
