### PR TITLE
Do not auto complete on fields with class 'no-chromeipass'

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -789,7 +789,7 @@ cipDefine.prepareStep3 = function() {
 
 cipFields = {}
 
-cipFields.inputQueryPattern = "input[type='text'], input[type='email'], input[type='password'], input:not([type])";
+cipFields.inputQueryPattern = "input[type='text']:not(.no-chromeipass), input[type='email']:not(.no-chromeipass), input[type='password']:not(.no-chromeipass), input:not([type]):not(.no-chromeipass)";
 // unique number as new IDs for input fields
 cipFields.uniqueNumber = 342845638;
 // objects with combination of username + password fields


### PR DESCRIPTION
We have a CRM where we can change the user/pass information of other users. ChromeIPasss also acts on these fields, setting the values for the currently logged in user, which is not what we want.

When ignoring fields with class `no-chromeipass` as in this pull request, we can prevent ChromeIPass from filling these field programmatically so we can be sure it won't fill them.