### PR TITLE
Remove sourceMappingURL to prevent 404 errors on every page

### DIFF
--- a/chromeipass/jquery-1.9.1.min.js
+++ b/chromeipass/jquery-1.9.1.min.js
@@ -1,5 +1,4 @@
 /*! jQuery v1.9.1 | (c) 2005, 2012 jQuery Foundation, Inc. | jquery.org/license
-//@ sourceMappingURL=jquery.min.map
 */
 
 /*


### PR DESCRIPTION
Or should i add the source map itself? http://code.jquery.com/jquery-1.9.1.min.map
