### PR TITLE
Removed sourceMappingURL from jquery-1.9.1.min.js

### DIFF
--- a/chromeipass/jquery-1.9.1.min.js
+++ b/chromeipass/jquery-1.9.1.min.js
@@ -1,6 +1,4 @@
-/*! jQuery v1.9.1 | (c) 2005, 2012 jQuery Foundation, Inc. | jquery.org/license
-//@ sourceMappingURL=jquery.min.map
-*/
+/*! jQuery v1.9.1 | (c) 2005, 2012 jQuery Foundation, Inc. | jquery.org/license */
 
 /*
 replace jQuery with cIPJQ (case-sensitiv)


### PR DESCRIPTION
[![Screenshot](https://fs.fnkr.net/gsFPmg5pskeF/raw)](https://fs.fnkr.net/gsFPmg5pskeF)

http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/
