### PR TITLE
ChromeIPass now triggers the "input" event to support AngularJS

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -1405,6 +1405,7 @@ cip.setValue = function(field, value) {
 	}
 	else {
 		field.val(value);
+		field.trigger('input');
 	}
 }
 


### PR DESCRIPTION
Angular uses the "input" event on input/textarea fields to track changes. This pull request adds a trigger of that event to cip.setValue
