### PR TITLE
Add type='number' as valid input type for credential selection. 

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -789,7 +789,7 @@ cipDefine.prepareStep3 = function() {
 
 cipFields = {}
 
-cipFields.inputQueryPattern = "input[type='text'], input[type='email'], input[type='password'], input[type='tel'], input:not([type])";
+cipFields.inputQueryPattern = "input[type='text'], input[type='email'], input[type='password'], input[type='tel'], input[type='number'], input:not([type])";
 // unique number as new IDs for input fields
 cipFields.uniqueNumber = 342845638;
 // objects with combination of username + password fields


### PR DESCRIPTION
This fixes #345. Example page [here](https://gbg.onlinedisclosures.co.uk/Authentication/Login?ReturnUrl=%2f).