### PR TITLE
Chrome - don't close popup after "Redetect credential fields"

### DIFF
--- a/chromeipass/popups/popup.js
+++ b/chromeipass/popups/popup.js
@@ -64,7 +64,6 @@ $(function() {
 			chrome.tabs.sendMessage(tab.id, {
 				action: "redetect_fields"
 			});
-			close();
 		});
 	});
 


### PR DESCRIPTION
It is annoying, because always after "Redetect credential fields" I click again and choose the right password.