### PR TITLE
Add hint for necessary configuration in Firefox

### DIFF
--- a/documentation/PassIFox.md
+++ b/documentation/PassIFox.md
@@ -19,8 +19,9 @@ The XPI can be installed using the link: https://passifox.appspot.com/passifox.x
 
 ### Configuration
 
-There is no explicit configuration necessary. PassIFox and KeePassHttp
-will communicate with each other on http://localhost:19455/
+There is no explicit configuration necessary. Only `Remember passwords for
+sites` in Firefox under Preferences > Security has to be enabled. PassIFox
+and KeePassHttp will communicate with each other on http://localhost:19455/
 
 When a login form is discovered for the first time, PassIFox will
 initialize itself and request an "Association" with KeePass (KeePassHttp).


### PR DESCRIPTION
Dear Perry,

I used Chrome and chromeIPass for a long time and switched to Firefox recently.
It took me a while to get PassIFox working till I found out, that it is necessary to have **Remember passwords for sites** enabled in Firefox.

Maybe this is obvious, but as I have all my passwords in KeePass, at least it was not obvious to me.

I added this as a hint to your documentation and commited this pull request.
Perhaps you find it useful.

Cheers,
Ralph