### PR TITLE
Notification controls

### DIFF
--- a/passifox/defaults/preferences/defaults.js
+++ b/passifox/defaults/preferences/defaults.js
@@ -1,1 +1,11 @@
+// default connection url
 pref("extensions.passifox.keepasshttp_url", "http://localhost:19455/");
+// allow enabling and disabling of passifox notifications.
+//  all enabled by default.
+pref("extensions.passifox.notification.kpf-db-note", true);
+pref("extensions.passifox.notification.kpf-error-note", true);
+pref("extensions.passifox.notification.kpf-running-note", true);
+pref("extensions.passifox.notification.kpf-associate-note", true);
+// set the default timeout (in seconds) for displaying an notification if enabled
+pref("extensions.passifox.notification.timeout", 30);
+// eof

--- a/passifox/modules/KeePassFox.jsm
+++ b/passifox/modules/KeePassFox.jsm
@@ -31,6 +31,7 @@ function KeePassFox() {
 
     this._prefBranch = Services.prefs.getBranch("signon.");
     this._myPrefs = Services.prefs.getBranch("extensions.passifox.");
+    this._myNotifyPrefs = Services.prefs.getBranch("extensions.passifox.notification.");
     let kpf = this;
     this._observer = {
         QueryInterface: XPCOMUtils.generateQI([Ci.nsIObserver,
@@ -246,21 +247,24 @@ KeePassFox.prototype = {
         return l.length > 0 ? [l[0].username, l[0].password] : null;
     },
     _showNotification: function(m, buttons, id) {
-        let win     = Services.wm.getMostRecentWindow("navigator:browser");
-        if (id) {
-            let notif = win.document.getElementById(id);
-            if (notif)
-                return notif;
+        // check based on ID if user has allowed this notification to be shown
+        if (kpf._myNotifyPrefs.getBoolPref(id)) {
+            let win     = Services.wm.getMostRecentWindow("navigator:browser");
+            if (id) {
+                let notif = win.document.getElementById(id);
+                if (notif)
+                    return notif;
+            }
+            let browser = win.gBrowser;
+            let box     = browser.getNotificationBox(browser.selectedBrowser);
+            let n       = box.appendNotification(m, null,
+                    "chrome://passifox/skin/keepass.png", 3, buttons);
+            // let the notification show for configured amout of seconds
+            n.timeout = Date.now() + kpf._myNotifyPrefs.getIntPref(timeout) * 1000;
+            if (id)
+                n.setAttribute("id", id);
+            return n;
         }
-        let browser = win.gBrowser;
-        let box     = browser.getNotificationBox(browser.selectedBrowser);
-        let n       = box.appendNotification(m, null,
-                "chrome://passifox/skin/keepass.png", 3, buttons);
-        // let the notification show for 30 seconds
-        n.timeout = Date.now() + 30 * 1000;
-        if (id)
-            n.setAttribute("id", id);
-        return n;
     },
     _test_associate: function() {
         if (this._associated)

--- a/passifox/modules/KeePassFox.jsm
+++ b/passifox/modules/KeePassFox.jsm
@@ -248,7 +248,7 @@ KeePassFox.prototype = {
     },
     _showNotification: function(m, buttons, id) {
         // check based on ID if user has allowed this notification to be shown
-        if (kpf._myNotifyPrefs.getBoolPref(id)) {
+        if (this._myNotifyPrefs.getBoolPref(id) == true) {
             let win     = Services.wm.getMostRecentWindow("navigator:browser");
             if (id) {
                 let notif = win.document.getElementById(id);
@@ -260,7 +260,7 @@ KeePassFox.prototype = {
             let n       = box.appendNotification(m, null,
                     "chrome://passifox/skin/keepass.png", 3, buttons);
             // let the notification show for configured amout of seconds
-            n.timeout = Date.now() + kpf._myNotifyPrefs.getIntPref(timeout) * 1000;
+            n.timeout = Date.now() + this._myNotifyPrefs.getIntPref("timeout") * 1000;
             if (id)
                 n.setAttribute("id", id);
             return n;


### PR DESCRIPTION
I reported issue about the problem of constant "KeePass is not running" notifications popping up on my browser.

I have noticed that multiple people are opening duplicate issues on this same problem so I finally decided to implement simple "fix" for this feature. Now user can choose what messages are displayed by editing values through about:config. Also as a bonus the lifetime of a popup can be configured from the same config tree as well.