### PR TITLE
Fix password encoding with special chars

### DIFF
--- a/chromeipass/background/keepass.js
+++ b/chromeipass/background/keepass.js
@@ -45,9 +45,9 @@ keepass.updateCredentials = function(callback, tab, entryId, username, password,
 	var iv = request.Nonce;
 
 
-	request.Login = keepass.encrypt(username, key, iv);
+	request.Login = keepass.encrypt(cryptoHelpers.encode_utf8(username), key, iv);
 
-	request.Password = keepass.encrypt(password, key, iv);
+	request.Password = keepass.encrypt(cryptoHelpers.encode_utf8(password), key, iv);
 	request.Url = keepass.encrypt(url, key, iv);
 	request.SubmitUrl = keepass.encrypt(url, key, iv);
 


### PR DESCRIPTION
Username and password come utf-8 encoded from KeepassX and get decoded
in chromeipass. Since they get decoded in KeepassX when adding a new
entry the data should also be encoded to utf-8 in chromeipass before
encryption to preserve special characters.