### PR TITLE
Prefer KeyboardEvent.key over KeyboardEvent.keyIdentifier since the latter is non-standard.

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -61,10 +61,10 @@ chrome.extension.onMessage.addListener(function(req, sender, callback) {
 // ctrl + shift + u = fill username + password
 window.addEventListener("keydown", function(e) {
 	if (e.ctrlKey && e.shiftKey) {
-		if (e.keyIdentifier == "U+0050") { // P
+		if (e.key == "KeyP" || e.keyIdentifier == "U+0050") { // P
 			e.preventDefault();
 			cip.fillInFromActiveElementPassOnly(false);
-		} else if (e.keyIdentifier == "U+0055") { // U
+		} else if (e.key == "KeyU" || e.keyIdentifier == "U+0055") { // U
 			e.preventDefault();
 			cip.fillInFromActiveElement(false);
 			var field =_f(cipFields.combinations[0].username);


### PR DESCRIPTION
Fixes #521

---

I'm not sure when `key` was introduced, so I've not taken out the `keyIdentifier` check in case there's some version of Chrome out there that only has `keyIdentifier`.