### PR TITLE
Fix chromeIPass autocomplete field on page load

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -69,6 +69,7 @@ window.addEventListener("keydown", function(e) {
 			cip.fillInFromActiveElement(false);
 			var field =_f(cipFields.combinations[0].username);
 			cipAutocomplete.init(field);
+			field.click();
 		}
 	}
 }, false);
@@ -107,8 +108,6 @@ cipAutocomplete.init = function(field) {
 		.click(cipAutocomplete.onClick)
 		.blur(cipAutocomplete.onBlur)
 		.focus(cipAutocomplete.onFocus);
-		
-	field.click();
 }
 
 cipAutocomplete.onClick = function() {


### PR DESCRIPTION
Fixes #523 by only clicking on the field automatically when we're specifically inputting via the keyboard shortcut, not on any (potentially automatic) fill-in attempt.