### PR TITLE
Chromeipass not respecting maxlength="" attribute #556

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -1418,6 +1418,15 @@ cip.fillInStringFields = function(fields, StringFields, filledInFields) {
 }
 
 cip.setValueWithChange = function(field, value) {
+
+	var attribute_maxlength = field.attr('maxlength');
+	if (typeof attribute_maxlength !== typeof undefined &&
+		$.isNumeric(attribute_maxlength) === true &&
+		attribute_maxlength > 0) {
+
+		value = value.substr(0, attribute_maxlength);
+	}
+
 	field.val(value);
 	field[0].dispatchEvent(new Event('input', {'bubbles': true}));
 	field[0].dispatchEvent(new Event('change', {'bubbles': true}));

--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -1419,12 +1419,14 @@ cip.fillInStringFields = function(fields, StringFields, filledInFields) {
 
 cip.setValueWithChange = function(field, value) {
 
-	var attribute_maxlength = field.attr('maxlength');
-	if (typeof attribute_maxlength !== typeof undefined &&
-		$.isNumeric(attribute_maxlength) === true &&
-		attribute_maxlength > 0) {
+	if (cip.settings.respectMaxLength === true) {
+		var attribute_maxlength = field.attr('maxlength');
+		if (typeof attribute_maxlength !== typeof undefined &&
+			$.isNumeric(attribute_maxlength) === true &&
+			attribute_maxlength > 0) {
 
-		value = value.substr(0, attribute_maxlength);
+			value = value.substr(0, attribute_maxlength);
+		}
 	}
 
 	field.val(value);

--- a/chromeipass/options/options.html
+++ b/chromeipass/options/options.html
@@ -277,6 +277,16 @@
 						</label>
 						<span class="help-block">Disables communicating errors and warnings via JavaScript alert.</span>
 					</p>
+					<p>
+						<label class="checkbox">
+							<input type="checkbox" name="respectMaxLength" value="0" /> Respect maxlength="" attribute on inputs.
+						</label>
+						<span class="help-block">Limit the field filled in to the maximum number of characters allowed by
+							maxlength="" in the input as set by the website admin?<br />
+							There is a possibility of this causing issues with sites that have decreased this value after
+							you have already created one, or have increased it before the fact and the password stored in keepass itself is longer than maxlength.
+						</span>
+					</p>
 				</div>
 			</div>
 


### PR DESCRIPTION
If you happen to copy and paste a password from within keepass that is longer than maxlength of the input on the website allows, your browser will then truncate the remaining data automatically. If you don't notice or see this happen then the password you have saved in keepass will actually be longer than the website allows.

Because of the way the automatic field filler system works, it would bypass the maxlength value and input a password that is too long and your login always fails. This change adds a checkbox to the options page that allows you to enforce the maxlength value onto the data being placed into the input element.

References issue #556 