### PR TITLE
Updated searchLogins: set realm to null if caught

### DIFF
--- a/passifox/components/loginmanagerstorage.js
+++ b/passifox/components/loginmanagerstorage.js
@@ -199,7 +199,7 @@ LoginManagerStorage.prototype = {
         try{
             realm = matchData.getProperty("httpRealm");
         } catch(e){
-            realm = '';
+            realm = null;
         }
 
         return this.findLogins(count, host, form, realm);


### PR DESCRIPTION
LoginHelper.jsm > doLoginsMatch() checks the httpRealm property of the submitted form login and the passifox login. All tests had formLogin.httpRealm as null, but passifox login.httpRealm was an empty string, as the realm was being caught and set in searchLogins.

Updated searchLogins to have realm set to null if caught.
# 555

https://github.com/pfn/passifox/issues/555#issuecomment-255604179
https://github.com/pfn/passifox/issues/555#issuecomment-256286539
