### PR TITLE
Added reference to the KeePassXC project in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PassIFox and chromeIPass
 
-are extensions for the browsers Mozilla Firefox and Google Chrome to integrate KeePass as password manager into these browsers.
+are extensions for the browsers Mozilla Firefox and Google Chrome to integrate KeePass(XC) as password manager into these browsers.
 
-They require [KeePassHttp](https://github.com/pfn/keepasshttp/), a plugin for KeePass which implements the communication for KeePass.
+They are compatible with [KeePassXC](https://keepassxc.org/) and [KeePass](http://keepass.info) (require [KeePassHttp](https://github.com/pfn/keepasshttp/), a plugin implementing the communication for KeePass).
 
 ## chromeIPass for Google Chrome
 
@@ -24,7 +24,7 @@ If you [open an issue](https://github.com/pfn/passifox/issues/) always give us a
 1. chromeIPass or PassIFox? and the version
 2. version of your browser
 2. KeePassHttp version
-3. KeePass version
+3. KeePass(XC) version
 4. Pages on which the error occur
 
 PassIFox & ChromeIPass Copyright (C) 2010-2015 Perry Nguyen  

--- a/documentation/PassIFox.md
+++ b/documentation/PassIFox.md
@@ -8,10 +8,12 @@ This extension is for use with [KeePassHttp](https://github.com/pfn/keepasshttp)
 
 The XPI can be installed using the link: https://passifox.appspot.com/passifox.xpi
 
-### Prereqs
+### Requirements
+- [KeePassXC](https://keepassxc.org/) v2.1.1 or higher
 
-1. [KeePass](http://keepass.info/)
-2. [KeePassHttp](https://github.com/pfn/keepasshttp/)
+OR
+- [KeePass](http://keepass.info/)
+- [KeePassHttp](https://github.com/pfn/keepasshttp/)
 
 ### Installation
 

--- a/documentation/chromeIPass.md
+++ b/documentation/chromeIPass.md
@@ -1,6 +1,6 @@
 # chromeIPass
 
-is an extension for the browser Google Chrome to send and receive credentials from KeePass through the plugin [KeePassHttp](https://github.com/pfn/keepasshttp).
+is an extension for the browser Google Chrome to send and receive credentials from KeePass(XC).
 <br />It can be downloaded from [Chrome Web Store](https://chrome.google.com/webstore/detail/chromeipass/ompiailgknfdndiefoaoiligalphfdae).
 
 Please read at least the section [Important information](#6-important-information).
@@ -63,9 +63,13 @@ Table of content:
 ## 2. Installation
 
 ### 2.1 Requirements
+- [KeePassXC](https://keepassxc.org/) v2.1.1 or higher
+
+OR
 - [KeePass](http://keepass.info) v2.17 or higher
 - [KeePassHttp](https://github.com/pfn/keepasshttp) v1.0.7 or higher (recommended v1.4 or higher)
-- it is recommended to disable the built-in Chrome password management when using this extension
+
+It is recommended to disable the built-in Chrome password management when using this extension
 
 ### 2.2 Installation
 1. Your database in KeePass has to be unlocked.
@@ -377,7 +381,7 @@ If this does not solve your problem, please [open an issue](https://github.com/p
 
 1. Check if you are using the [latest version of chromeIPass](https://chrome.google.com/webstore/detail/chromeipass/ompiailgknfdndiefoaoiligalphfdae).
 2. Check if your browser Google chrome is up-to-date
-3. Check if your versions of [KeePassHttp](https://github.com/pfn/keepasshttp) and [KeePass](http://www.keepass.info) are up-to-date
+3. Check if your versions of [KeePassXC](https://keepassxc.org/) OR ([KeePassHttp](https://github.com/pfn/keepasshttp) + [KeePass](http://www.keepass.info)) are up-to-date
 
 #### 8.2.2 Check the background page console for error messages
 1. Open a tab with URL _chrome://extensions_ and activate the _Developer mode_ to be able to generate the background page:<br />

--- a/passifox/install.rdf
+++ b/passifox/install.rdf
@@ -10,7 +10,7 @@
     </em:targetApplication>
     <!-- Front End MetaData -->
     <em:name>PassIFox</em:name>
-    <em:description>KeePass Login Manager Storage and Integration using the KeePassHttp plugin</em:description>
+    <em:description>KeePass(XC) Login Manager Storage and Integration using the KeePassHttp plugin</em:description>
     <em:iconURL>chrome://passifox/skin/keepass-big.png</em:iconURL>
     <em:creator>Perry Nguyen</em:creator>
     <em:homepageURL>https://github.com/pfn/passifox</em:homepageURL>


### PR DESCRIPTION
Since KeePassXC release 2.1.1 comes builtin with keepassHTTP. It is worth mentioning it in the user documentation ( see issue #585 ).