### PR TITLE
chromeipass: keyboard shortcuts using the commands API

### DIFF
--- a/chromeipass/background/init.js
+++ b/chromeipass/background/init.js
@@ -142,6 +142,27 @@ chrome.contextMenus.create({
 	}
 });
 
+/**
+ * Listen for keyboard shortcuts specified by user
+ */
+chrome.commands.onCommand.addListener(function(command) {
+
+	if(command === "fill-username-password") {
+		chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+			if (tabs.length) {
+				chrome.tabs.sendMessage(tabs[0].id, { action: "fill_user_pass" });
+			}
+		});
+	}
+
+	if(command === "fill-password") {
+		chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+			if (tabs.length) {
+				chrome.tabs.sendMessage(tabs[0].id, { action: "fill_pass_only" });
+			}
+		});
+	}
+});
 
 /**
  * Interval which updates the browserAction (e.g. blinking icon)

--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -58,26 +58,6 @@ chrome.extension.onMessage.addListener(function(req, sender, callback) {
 	}
 });
 
-// Hotkeys for every page
-// ctrl + shift + p = fill only password
-// ctrl + shift + u = fill username + password
-window.addEventListener("keydown", function(e) {
-	if (e.ctrlKey && e.shiftKey) {
-		if (e.key == "KeyP" || e.keyIdentifier == "U+0050") { // P
-			e.preventDefault();
-			cip.receiveCredentialsIfNecessary();
-			cip.fillInFromActiveElementPassOnly(false);
-		} else if (e.key == "KeyU" || e.keyIdentifier == "U+0055") { // U
-			e.preventDefault();
-			cip.receiveCredentialsIfNecessary();
-			cip.fillInFromActiveElement(false);
-			var field =_f(cipFields.combinations[0].username);
-			cipAutocomplete.init(field);
-			field.click();
-		}
-	}
-}, false);
-
 function _f(fieldId) {
 	var field = (fieldId) ? cIPJQ("input[data-cip-id='"+fieldId+"']:first") : [];
 	return (field.length > 0) ? field : null;

--- a/chromeipass/manifest.json
+++ b/chromeipass/manifest.json
@@ -41,6 +41,22 @@
 			"all_frames": true
 		}
 	],
+	"commands": {
+		"fill-username-password": {
+			"description": "Insert username + password",
+			"suggested_key": {
+				"default": "Ctrl+Shift+U",
+				"mac": "Command+Shift+U"
+			}
+		},
+		"fill-password": {
+			"description": "Insert a password",
+			"suggested_key": {
+				"default": "Ctrl+Shift+P",
+				"mac": "Command+Shift+P"
+			}
+		}
+	},
 	"web_accessible_resources": [
 		"jquery.min.map",
 		"icons/key_16x16.png",
@@ -56,6 +72,7 @@
 		"images/ui-bg_highlight-soft_75_cccccc_1x100.png"
 	],
 	"permissions": [
+		"activeTab",
 		"contextMenus",
 		"clipboardWrite",
 		"tabs",

--- a/chromeipass/options/options.html
+++ b/chromeipass/options/options.html
@@ -123,9 +123,9 @@
 				<h2>General Settings</h2>
 				<hr />
 				<p>
-					If you just want to insert username + password into the fields where your focus is, press Ctrl + Shift + U.
+					If you just want to insert username + password into the fields where your focus is, press <code>Ctrl + Shift + U</code>.
 					<br />
-					If you only want to insert the password, just press Ctrl + Shift + P.
+					If you only want to insert the password, just press <code>Ctrl + Shift + P</code>. You can customize these shortcuts on <code>chrome://extensions/configureCommands</code> page.
 				</p>
 				<p>
 					<label for="blinkTimeout">Blink Time:</label>


### PR DESCRIPTION
Fixing the broken keyboard shortcuts reported below.

This PR leaves [chromeipass.js code](https://github.com/pfn/passifox/blob/master/chromeipass/chromeipass.js#L64) untouched, but it might be a good idea to remove it.

- see #559
- see #488