### PR TITLE
Added popup confirmation option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 chromeipass.pem
 /chromeipass-data/
 .idea/
+
+*.sublime-workspace
+
+*.sublime-project

--- a/chromeipass/background/keepass.js
+++ b/chromeipass/background/keepass.js
@@ -76,6 +76,18 @@ keepass.updateCredentials = function(callback, tab, entryId, username, password,
 }
 
 keepass.retrieveCredentials = function (callback, tab, url, submiturl, forceCallback, triggerUnlock) {
+
+	// if setting is active ask if password should be filled
+	if(page.settings.popupAutoFill){
+		var r = confirm("Should credentials for \n \n" + url + "\n \nbe retrived ?");
+		if (r == false) {
+			if(forceCallback) {
+				callback([]);
+			}
+		    return;
+		};
+	}
+
 	page.debug("keepass.retrieveCredentials(callback, {1}, {2}, {3}, {4})", tab.id, url, submiturl, forceCallback);
 
 	// unset error message

--- a/chromeipass/background/page.js
+++ b/chromeipass/background/page.js
@@ -24,6 +24,9 @@ page.initSettings = function() {
 	if(!("autoFillSingleEntry" in page.settings)) {
 		page.settings.autoFillSingleEntry = 1;
 	}
+	if(!("popupAutoFill" in page.settings)) {
+		page.settings.popupAutoFill = false;
+	}
 	if(!("autoRetrieveCredentials" in page.settings)) {
 		page.settings.autoRetrieveCredentials = 1;
 	}

--- a/chromeipass/options/options.html
+++ b/chromeipass/options/options.html
@@ -202,6 +202,13 @@
 				</p>
 				<hr />
 				<p>
+					<label class="checkbox">
+						<input type="checkbox" name="popupAutoFill" value="0" /> Show Popup before retriving credentials.
+					</label>
+					<span class="help-block">Show a popup to confirm password autofilling. Protects against hidden inputs.</span>
+				</p>
+				<hr />
+				<p>
 					Check for updates of KeePassHttp:
 					<br />
 					<label class="radio inline"><input type="radio" name="checkUpdateKeePassHttp" value="3" /> every 3 days</label>


### PR DESCRIPTION
Added an option to display a popup inside the browser before the password gets filled in.

## Reasons
There have been reported cases of server side bundeling of hidden input fields to trick autofill plugins into filling in userdata. To my knowledge this has mostly been done for ad tracking but could also be used to steal credentials. https://www.theverge.com/2017/12/30/16829804/browser-password-manager-adthink-princeton-research

## Note
You could already confirm autofill per entry by clicking inside keepass but you had to leave the browser, this way is more convenient and no less secure if the user already had Keepass on "allow" and "remember decision"  
  
I had some trouble finding the best place for the little code piece, i think it is a good soulution as is right now but if you prefere some other location just let me know.