### PR TITLE
Fix selector for 'id' to support semi-colons

### DIFF
--- a/chromeipass/chromeipass.js
+++ b/chromeipass/chromeipass.js
@@ -802,7 +802,7 @@ cipFields.setUniqueId = function(field) {
 }
 
 cipFields.prepareId = function(id) {
-	return id.replace(/[:#.,\[\]\(\)' "]/g, function(m) {
+	return id.replace(/[:#.,;\[\]\(\)' "]/g, function(m) {
 												return "\\"+m
 											});
 }


### PR DESCRIPTION
The current `preparedId` function produces a jQuery selector that fails on ids containing a `;`.

The failure I encountered was on an internal SSO page that was generating ids for controls using values like `34:2;a`.  ChromeIPass was generating errors in the console, and even though the `prepareId` function was escaping some characters, the semi-colon was not included in the set.  Adding the semi-colon to the set of characters being escaped corrected the issue.