### PR TITLE
Add Pale Moon entry to install.rdf

### DIFF
--- a/passifox/install.rdf
+++ b/passifox/install.rdf
@@ -2,11 +2,19 @@
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
   <Description about="urn:mozilla:install-manifest">
     <em:id>passifox@hanhuy.com</em:id>
-    <em:version>1.2.2</em:version>
+    <em:version>1.2.3</em:version>
     <em:type>2</em:type>
     <!-- firefox -->
     <em:targetApplication>
       <Description em:id="{ec8030f7-c20a-464f-9b0e-13a3a9e97384}" em:minVersion="4.0b1" em:maxVersion="49.*"/>
+    </em:targetApplication>
+    <!-- pale moon -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}</em:id>
+        <em:minVersion>25.0</em:minVersion>
+        <em:maxVersion>29.*</em:maxVersion>
+      </Description>
     </em:targetApplication>
     <!-- Front End MetaData -->
     <em:name>PassIFox</em:name>


### PR DESCRIPTION
As of v29.2.0, Pale Moon will no longer try to load a browser extension built for legacy Firefox unless the install.rdf also targets Pale Moon (see https://forum.palemoon.org/viewtopic.php?f=1&t=26657 ).  Passifox used to work on Pale Moon without any modifications; now, it works on Pale Moon, but only when the install.rdf of the .xpi file is updated.

On my end, I was able to get a passifox.xpi working in Pale Moon after making these changes to the project's install.rdf file.